### PR TITLE
Polished command-line output, for parsing and IDE integration.

### DIFF
--- a/src/main/java/fr/uga/pddl4j/parser/Message.java
+++ b/src/main/java/fr/uga/pddl4j/parser/Message.java
@@ -274,7 +274,7 @@ public class Message implements Serializable, Comparable<Message> {
         }
         str.append(" at line ").append(this.line).append(", column ").append(this.column)
             .append(", file (").append(this.file).append(")")
-            .append(" : ").append(this.content);
+            .append(" : ").append(this.content).append('\n');
         return str.toString();
 
 

--- a/src/main/java/fr/uga/pddl4j/parser/Parser.java
+++ b/src/main/java/fr/uga/pddl4j/parser/Parser.java
@@ -1185,7 +1185,7 @@ public final class Parser {
                 parser.mgr.printAll();
             }
         } else if (args.length == 4 && "-o".equals(args[0]) && "-f".equals(args[2])) {
-            strb.append("parse files ").append("\"").append(args[1]).append("\" and ").append("\"").append(args[3])
+            strb.append("Parsed files ").append("\"").append(args[1]).append("\" and ").append("\"").append(args[3])
                 .append("\": ");
             Parser parser = new Parser();
             try {
@@ -1196,7 +1196,7 @@ public final class Parser {
             if (parser.mgr.isEmpty()) {
                 strb.append("ok");
             } else {
-                strb.append("no ok");
+                strb.append("not ok");
                 parser.mgr.printAll();
             }
         } else {


### PR DESCRIPTION
Owners, I am proposing a minor change in the console output, which makes the output parsable. This helps in order to use the planner in an integrated developer environment, while modeling PDDL domains comfortably. 
With these changes, the planner can be configured and used by this Visual Studio Code PDDL Extension:
https://marketplace.visualstudio.com/items?itemName=jan-dolejsi.pddl

Here is a description of how the pddl4j can be configured as a PDDL parser:
https://github.com/jan-dolejsi/vscode-pddl/wiki/Configuring-the-PDDL-parser#pddl4j