### PR TITLE
Use HashSet for breath-first search closeSet 

### DIFF
--- a/src/main/java/fr/uga/pddl4j/planners/statespace/search/strategy/BreadthFirstSearch.java
+++ b/src/main/java/fr/uga/pddl4j/planners/statespace/search/strategy/BreadthFirstSearch.java
@@ -21,6 +21,7 @@ import fr.uga.pddl4j.util.BitState;
 import fr.uga.pddl4j.util.MemoryAgent;
 import fr.uga.pddl4j.util.SolutionEvent;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Objects;
 
@@ -64,7 +65,7 @@ public final class BreadthFirstSearch extends AbstractStateSpaceStrategy {
         Objects.requireNonNull(codedProblem);
         final long begin = System.currentTimeMillis();
 
-        final LinkedList<Node> closeSet = new LinkedList<>();
+        final HashSet<Node> closeSet = new HashSet<>();
         final LinkedList<Node> openSet = new LinkedList<>();
         final int timeout = getTimeout();
 


### PR DESCRIPTION
The breath-first search can be sped up considerably by using a `HashSet` instead of a `LinkedList` for the `closeSet` since it can handle the `contains` method a lot faster.