### PR TITLE
update javadoc code example for Parser

### DIFF
--- a/src/main/java/fr/uga/pddl4j/parser/Parser.java
+++ b/src/main/java/fr/uga/pddl4j/parser/Parser.java
@@ -71,7 +71,7 @@ import java.util.stream.Collectors;
  *          System.out.println(e.getMessage());
  *        }
  *      if (!parser.getErrorManager().isEmpty()) {
- *          parser.mgr.printAll();
+ *          parser.getErrorManager().printAll();
  *        }
  *    } else {
  *      System.out.println(&quot;\nusage of parser:\n&quot;);


### PR DESCRIPTION
In javadoc example: the field `parser.mgr` is not visible, replaced it with  `parser.getErrorManager()`