### PR TITLE
Update testPlan with version 4.0.0

### DIFF
--- a/src/test/resources/validators/testPlan.sh
+++ b/src/test/resources/validators/testPlan.sh
@@ -1,56 +1,111 @@
 #!/bin/bash
 
-VERSION=3.8.3
-PROBLEM=""
-TYPE=""
+XM=256m
+VERSION=4.0.0
 
-echo "### Execute 20 HSP planifications on blocks world problems"
-TYPE=blocksworld
-for ((i=1 ; i<21 ; i++))
-    do
-    if [ ${i} -lt 10 ]
-        then PROBLEM=p0${i}.pddl
-    else
-        PROBLEM=p${i}.pddl
-    fi
-    java -javaagent:build/libs/pddl4j-${VERSION}.jar -server -Xms2048m -Xmx2048m fr.uga.pddl4j.planners.statespace.StateSpacePlannerFactory -o pddl/${TYPE}/domain.pddl -f pddl/${TYPE}/${PROBLEM}
-done
+# Planner Data
+statespace=fr.uga.pddl4j.planners.statespace.HSP
+heuristic="MAX"
+logLevel="INFO"
+timeout="600"
+weight="1.0"
+domain_name="domain"
+problem_name=""
+complete_path=""
 
-echo "### Execute 4 HSP planifications on depots problems"
-TYPE=depots
-for ((i=1 ; i<5 ; i++))
-    do
-     if [ ${i} -lt 10 ]
-        then PROBLEM=p0${i}.pddl
-    else
-        PROBLEM=p${i}.pddl
-    fi
-    java -javaagent:build/libs/pddl4j-${VERSION}.jar -server -Xms2048m -Xmx2048m fr.uga.pddl4j.planners.statespace.StateSpacePlannerFactory -o pddl/${TYPE}/domain.pddl -f pddl/${TYPE}/${PROBLEM}
-done
+# path
+#  The base path of benchmarks.
+path="src/test/resources/benchmarks/pddl"
 
-echo "### Execute 5 HSP planifications on gripper problems"
-TYPE=gripper
-for ((i=1 ; i<6 ; i++))
-    do
-     if [ ${i} -lt 10 ]
-        then PROBLEM=p0${i}.pddl
-    else
-        PROBLEM=p${i}.pddl
-    fi
-    java -javaagent:build/libs/pddl4j-${VERSION}.jar -server -Xms2048m -Xmx2048m fr.uga.pddl4j.planners.statespace.StateSpacePlannerFactory -o pddl/${TYPE}/domain.pddl -f pddl/${TYPE}/${PROBLEM}
-done
+# ipc_folders
+#  The array of ipc’s folders where the benchmark at the same index are.
+#  The size of this array must be the same as "benchmarks" and "benchmarks_types".
+ipc_folders=("ipc2000" "ipc2002" "ipc1998" "ipc1998")
 
-echo "### Execute 11 HSP planifications on logistics problems"
-TYPE=logistics
-for ((i=1 ; i<12 ; i++))
-    do
-     if [ ${i} -lt 10 ]
-        then PROBLEM=p0${i}.pddl
-    else
-        PROBLEM=p${i}.pddl
-    fi
-    java -javaagent:build/libs/pddl4j-${VERSION}.jar -server -Xms2048m -Xmx2048m fr.uga.pddl4j.planners.statespace.StateSpacePlannerFactory -o pddl/${TYPE}/domain.pddl -f pddl/${TYPE}/${PROBLEM}
-done
+# benchmarks
+#  The array of benchmark’s folders we want to use.
+#  The size of this array must be the same as "ipc_folders" and "benchmarks_types".
+benchmarks=("blocks" "depots" "gripper" "logistics")
 
+# benchmark_types
+#  The array of types of problem (of the benchmark at the same index) we want to plan.
+#  The size of this array must be the same as "ipc_folders" and "benchmarks".
+benchmark_types=("strips-typed" "strips-automatic" "strips" "strip-round1")
 
+# nb_pddl_to_do
+#  Variable that represents the number of pddl problem to run in each beachmark
+#  The default value: 20 represents the min max number of problem’s files
+#  between the 4 default benchmarks folder.
+nb_pddl_to_do=20
+
+# index_folder
+#  Variable used to navigate between folders
+#  MUST NOT be changed
+index_folder=0
+
+# index_file
+#  SHOULD NOT be changed unless the first problem file start at 0
+#  Example :p000.pddl
+index_file=1
+
+# Configurate the output folders
+function configuration() {
+    echo "### Remove and create output folders"
+    echo
+    for (($((index_folder = 0)); $index_folder < ${#benchmarks[@]}; $((index_folder++)))); do
+        echo "# ${benchmarks[index_folder]} output folder"
+        rm -rf "${benchmarks[index_folder]}"
+        mkdir "${benchmarks[index_folder]}"
+    done
+    echo
+}
+
+# Run all benchmarks and solve each problem using HSP planner
+function run_benchmarks() {
+    for (($((index_folder = 0)); $index_folder < ${#benchmarks[@]}; $((index_folder++)))); do
+        # Create the right path to use for this loop
+        complete_path="$path/${ipc_folders[index_folder]}/${benchmarks[index_folder]}/${benchmark_types[index_folder]}"
+
+        # Execute 20 HSP Planifications
+        echo "### Execute 20 HSP planifications on ${benchmarks[index_folder]}"
+        echo
+        for (($((index_file = 1)); $index_file <= $nb_pddl_to_do; $((index_file++)))); do
+            # Find the correct name of the pddl problem (example sp001.pddl or p011.pddl or p111.pddl)
+            if [ ${index_file} -lt 10 ]; then
+                problem_name=p00${index_file}.pddl
+            else
+                if [ ${index_file} -lt 100 ]; then
+                    problem_name=p0${index_file}.pddl
+                else
+                    problem_name=p${index_file}.pddl
+                fi
+            fi
+            # Solve using HSP Planner
+            solveHSP
+        done
+        echo
+    done
+}
+
+# Run HSP Planner
+function solveHSP() {
+    echo "# Plan ${problem_name}"
+
+    java \
+        -Xms${XM} \
+        -Xmx${XM} \
+        -javaagent:build/libs/pddl4j-${VERSION}.jar \
+        fr.uga.pddl4j.planners.statespace.HSP \
+        ${complete_path}/${domain_name}.pddl \
+        ${complete_path}/${problem_name} \
+        --heuristic=${heuristic} \
+        --log=${logLevel} \
+        --timeout=${timeout} \
+        --weight=${weight} \
+        >${benchmarks[index_folder]}/${benchmarks[index_folder]}_${index_file}.txt
+}
+# MUST BE RUN FROM PDDL4J/
+# bash ./src/test/resources/validators/testPlan.sh
+configuration
+run_benchmarks
 exit 0

--- a/src/test/resources/validators/testPlan.sh
+++ b/src/test/resources/validators/testPlan.sh
@@ -55,7 +55,7 @@ function configuration() {
     for (($((index_folder = 0)); $index_folder < ${#benchmarks[@]}; $((index_folder++)))); do
         echo "# ${benchmarks[index_folder]} output folder"
         rm -rf "${benchmarks[index_folder]}"
-        mkdir "${benchmarks[index_folder]}"
+        # mkdir "${benchmarks[index_folder]}"
     done
     echo
 }
@@ -90,7 +90,7 @@ function run_benchmarks() {
 # Run HSP Planner
 function solveHSP() {
     echo "# Plan ${problem_name}"
-
+    timeout 60 \
     java \
         -Xms${XM} \
         -Xmx${XM} \


### PR DESCRIPTION
# Before
The previous version was using the version 3.8.3 of pddl with four different loops.

# Replaced by
1. The tag `VERSION` is now to `4.0.0`
2. The loops are replaced by the function `run_benchmarks`

## Various variables
- `XM`: java memory allocation.
- `COMMANDTIMEOUT`: the timeout applied to the process.

### Planner variables
These variables are the same as the command line syntax to launch the [HSP Planner](http://pddl4j.imag.fr/running_planners_from_command_line.html#hsp-heuristic-search-planner)

| Name          | Description                                                               | Default |
|---------------|---------------------------------------------------------------------------|---------|
| statespace    | set the planner                                                           | HSP     |
| heuristic     | set the heuristic of the planner                                          | MAX     |
| logLevel      | set the level of trace                                                    | INFO    |
| timeout       | set the time out of the planner in second                                 | 600     |
| weight        | set the weight of the heuristic                                           | 1.0     |
| domain_name   | set the name of the *domain* file. This name is common for each benchmark | domain  |
| problem_name  | set the name of the *problem* file.                                       |         |
| complete_path | set the complete path to find the *pddl files* **From pddl4j/ folder**.     |         |

### Directory variables
We can find the *pddl files* in this type of path: `src/test/resources/benchmarks/pddl/ipc1998/gripper/strips`.
So we are loop throught 3 *types* of folder:
1. The **ipc** folders (`ipc1998`, `ipc2000`, ... , `ipc2014`) represented by the array `ipc_folders`.
2. The **benchmarks** folder (`blocks`, ... , `logistics`) represented by the array `benchmarks`.
4. The **type** of *pddl files* (`strips`, `strips-hand-coded` ...) represented by the array `benchmark_types`.

### Iteration variables
| Name          | Description                          | Default |
|---------------|--------------------------------------|---------|
| index_folder  | iterator to navigate between folders | 0       |
| index_file    | iterator to navigate between files   | 1       |
## Functions
### `configuration()`
The configuration function is used to create folder in which the output *text files*  created by the `solveHSP` function will be placed in.
**If the folder already exists (from a previous run), it will be deleted).**

### `run_benchmarks()`
Run all benchmarks and solve all *pddl problems* using *HSP planner*.
- Here the run_benchmarks will iterate through:
    1. `src/test/resources/benchmarks/pddl/ipc2000/blocks/strips-typed`
    2. `src/test/resources/benchmarks/pddl/ipc2002/depots/strips-automatic`
    3. `src/test/resources/benchmarks/pddl/ipc1998/gripper/strips`
    4. `src/test/resources/benchmarks/pddl/ipc1998/logistics/strips-round1`
- Use the `src/test/resources/benchmarks/pddl/[ipc_folders]/[benchmarks]/[benchmark_types]/domain.pddl` file.
-  Iterate throught all *pddl files* in this benchmark’s folder.
- And solve this *problem* using this *domain* with the  `solveHSP()` function.

### `solveHSP()`
Use HSP planner to plan the `problem_name` *problem file* using `domain_name` *domain file* with the several **planner options**. The output of this planification will be written inside a *text file* named `${benchmarks[index_folder]}/${benchmarks[index_folder]}_${index_file}.txt`.
After a run, we can find files like : `blocks/blocks_1.txt`, `depots/depots_15.txt`.

# Run the bash script
Because this script is using the *pddl library* stored in `pddl4j/build/libs/` folder.
We  **must** run this script from `pddl4j/` folder.
```bash
bash src/test/resources/validators/testPlan.sh
```

# Authors
@hugoapeloig
@maleusa
@mathysc