### PR TITLE
Update gradle-wrapper.properties from version 7.0 to 7.6.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip


### PR DESCRIPTION
Hi, 

I would like to suggest updating the gradle version of the shipped wrapper from 7.0.2 to 7.6.4 (at the time of this post the latest 7.x version). The reason for this suggestion is, that currently the library does not build with JDK17+.

Regards. 